### PR TITLE
Remove the html body from the wrapped error in client.do.

### DIFF
--- a/ftx/client.go
+++ b/ftx/client.go
@@ -121,7 +121,7 @@ func (c *Client) do(uri string, method string, in, out interface{}, isPrivate bo
 		data.Result = out
 	}
 	if err := json.Unmarshal(resp.Body(), &data); err != nil {
-		return fmt.Errorf("unmarshal: [%v] body: %v, error: %v", resp.StatusCode(), string(resp.Body()), err)
+		return fmt.Errorf("unmarshal: [%v], error: %w", resp.StatusCode(), err)
 	}
 	if !data.Success {
 		return errors.New(data.Error)

--- a/ftx/client_test.go
+++ b/ftx/client_test.go
@@ -65,7 +65,7 @@ func TestClient_Do(t *testing.T) {
 		err := c.DoPrivate(testURL, http.MethodGet, nil, nil)
 
 		assert.Error(t, err)
-		assert.Equal(t, "unmarshal: [500] body: wrong body, error: invalid character 'w' looking for beginning of value", err.Error())
+		assert.Equal(t, "unmarshal: [500], error: invalid character 'w' looking for beginning of value", err.Error())
 	})
 }
 


### PR DESCRIPTION
With this change the HTML response body, containing no useful information, will not be added to the wrapped error.